### PR TITLE
Preventing notices on certain cases

### DIFF
--- a/inc/language-api/Mlp_Language_Api.php
+++ b/inc/language-api/Mlp_Language_Api.php
@@ -468,7 +468,7 @@ class Mlp_Language_Api implements Mlp_Language_Api_Interface {
 				$tags[ $site_id ] = str_replace('_', '-', $data[ 'text' ] );
 
 			// a site might have just 'EN' as text and no other values
-			if ( FALSE === strpos( $tags[ $site_id ], '-' ) ) {
+			if ( isset( $tags[ $site_id ] ) && FALSE === strpos( $tags[ $site_id ], '-' ) ) {
 				$tags[ $site_id ] = strtolower( $tags[ $site_id ] );
 				$add_like[ $site_id ] = $tags[ $site_id ];
 			}


### PR DESCRIPTION
I noticed some errors that were generated by this on a legacy site; i'm not sure in which cases it skips previous two conditionals, but this will prevent further errors.