### PR TITLE
Delete site option 'state_modules' on uninstall

### DIFF
--- a/src/uninstall.php
+++ b/src/uninstall.php
@@ -56,6 +56,7 @@ foreach ( array ( 'mlp_languages', 'multilingual_linked', 'mlp_site_relations' )
 delete_site_option( 'inpsyde_multilingual' );
 delete_site_option( 'inpsyde_multilingual_cpt' );
 delete_site_option( 'inpsyde_multilingual_quicklink_options' );
+delete_site_option( 'state_modules' );
 delete_site_option( 'mlp_version' );
 delete_site_option( 'multilingual_press_check_db' );
 


### PR DESCRIPTION
The module manager is creating the site option 'state_modules' on database to manage the modules, but this value is not removed if the plugin is uninstalled. This will cause multiple entries on the database that can generate unexpected behaviours because the get_site_option method return the first entry found on the database.