### PR TITLE
Don't filter URLs used for hreflangs.

### DIFF
--- a/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
+++ b/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
@@ -108,7 +108,10 @@ class Mlp_Hreflang_Header_Output {
 		$this->translations = array();
 
 		/** @var Mlp_Translation_Interface[] $translations */
-		$translations = $this->language_api->get_translations( array( 'include_base' => true ) );
+		$translations = $this->language_api->get_translations( array(
+			'include_base'     => true,
+			'suppress_filters' => true,
+		) );
 		if ( ! $translations ) {
 			return $this->translations;
 		}

--- a/src/inc/language-api/Mlp_Language_Api.php
+++ b/src/inc/language-api/Mlp_Language_Api.php
@@ -341,6 +341,8 @@ class Mlp_Language_Api implements Mlp_Language_Api_Interface {
 				$arr[ 'icon' ] = '';
 			}
 
+			$arr['suppress_filters'] = $arguments['suppress_filters'];
+
 			$arr = new Mlp_Translation( $arr, new Mlp_Language( $data ) );
 		}
 
@@ -660,16 +662,17 @@ WHERE `http_name` IN( $values )";
 	 */
 	private function prepare_translation_arguments( Array $args ) {
 
-		$defaults = array (
+		$defaults = array(
 			// always greater than 0
-			'site_id'              => get_current_blog_id(),
+			'site_id'          => get_current_blog_id(),
 			// 0 if missing
-			'content_id'           => $this->get_query_id(),
-			'type'                 => $this->get_request_type(),
-			'strict'               => TRUE,
-			'search_term'          => get_search_query(),
-			'post_type'            => $this->get_request_post_type(),
-			'include_base'         => FALSE
+			'content_id'       => $this->get_query_id(),
+			'type'             => $this->get_request_type(),
+			'strict'           => true,
+			'search_term'      => get_search_query(),
+			'post_type'        => $this->get_request_post_type(),
+			'include_base'     => false,
+			'suppress_filters' => false,
 		);
 
 		$arguments = wp_parse_args( $args, $defaults );

--- a/src/inc/types/Mlp_Translation.php
+++ b/src/inc/types/Mlp_Translation.php
@@ -49,6 +49,11 @@ class Mlp_Translation implements Mlp_Translation_Interface {
 	private $target_title;
 
 	/**
+	 * @var bool
+	 */
+	private $suppress_filters = false;
+
+	/**
 	 * @param array        $params
 	 * @param Mlp_Language_Interface $language
 	 */
@@ -62,6 +67,10 @@ class Mlp_Translation implements Mlp_Translation_Interface {
 		$this->page_type         = $params['type'];
 		$this->icon_url          = $params['icon'];
 		$this->language          = $language;
+
+		if ( isset( $params['suppress_filters'] ) ) {
+			$this->suppress_filters = (bool) $params['suppress_filters'];
+		}
 	}
 
 	/**
@@ -108,6 +117,10 @@ class Mlp_Translation implements Mlp_Translation_Interface {
 	 * @return string
 	 */
 	public function get_remote_url() {
+
+		if ( $this->suppress_filters ) {
+			return (string) $this->remote_url;
+		}
 
 		/**
 		 * Filter the remote URL of the linked element.


### PR DESCRIPTION
Introduce a new parameter `suppress_filters` to render unfiltered URLs (for `hreflang`s).