### PR TITLE
#243 added missing "current"-class for nav-menu-item

### DIFF
--- a/src/inc/nav-menu/Mlp_Nav_Menu_Frontend.php
+++ b/src/inc/nav-menu/Mlp_Nav_Menu_Frontend.php
@@ -107,6 +107,10 @@ class Mlp_Nav_Menu_Frontend {
 		/** This filter is documented in inc/types/Mlp_Translation.php */
 		$item->url = apply_filters( 'mlp_linked_element_link', $url, $site_id, 0, $translation );
 
+		if ( get_current_blog_id() === $site_id ) {
+			$item->classes[] = 'mlp-current-language-nav-item';	
+		}
+		
 		/**
 		 * Runs before a nav menu item is sent to the walker.
 		 *


### PR DESCRIPTION
#### What's Included in This Pull Request
* Added check for `get_current_blog_id() === $site_id` in `Mlp_Nav_Menu_Frontend:prepare_item()` and added new css class `mlp-current-language-nav-item` if TRUE.

See issue: #243
